### PR TITLE
avoids IDE errors running tests: learn test -> learn

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This line reads `index.js` (remember how we said we'd modify that?) and adds its
 
 ## Running the Tests
 
-To run the tests, simply type `learn test` in the terminal part of the Learn IDE. (The terminal is the part below where you've been coding.) You should see something like
+To run the tests, simply type `learn` in the terminal part of the Learn IDE. (The terminal is the part below where you've been coding.) You should see something like
 
 ![failures](https://curriculum-content.s3.amazonaws.com/skills-based-js/console_logging_lab_all_failing.png)
 
@@ -123,7 +123,7 @@ Because it seems sufficiently dire. Remember to save your file.
 Anyway, let's run the tests again. In the Learn IDE's terminal, run
 
 ``` javascript
-learn test
+learn
 ```
 
 We should now see:


### PR DESCRIPTION
@aturkewi 

`learn test` has caused errors for students using the IDE for this lab, `learn` doesn't trigger those same errors. This change in the instructions will prevent lots of questions being asked.